### PR TITLE
fix broken github path used for blog header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ url: "http://seahorn.github.io/" # the base hostname & protocol for your site
 
 author:
   fullname: SeaHorn
-  github: https://github.com/seahorn/seahorn
+  github: seahorn/seahorn
   #twitter: electrik_frog
   # disqus: your_disqus_forum_shortname
 


### PR DESCRIPTION
![image](https://im4.ezgif.com/tmp/ezgif-4-56808fdf2c79.gif)

The `https://github.com/` prefix isn't needed in `site.author.github` because the header HTML [prepends it](https://github.com/seahorn/seahorn.github.io/blob/fcaab77cd3ef1242990fce61dda7318ce1e9355b/_includes/header.html#L13) anyways.
