### PR TITLE
Fix: link to GitHub had wrong domain.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
 
     <ul class="social-links">
         {% if site.author.github %}
-            <a href="https://github.com/{{ site.author.github }}" class="social-links__entry" target="_blank">
+            <a href="{{ site.author.github }}" class="social-links__entry" target="_blank">
                 <i class="fa fa-github"></i>
             </a>
         {% endif %}


### PR DESCRIPTION
The yml file `_config.yml` sets `site.author.github` to `https://github.com/seahorn/seahorn`. As a consequence, the header on each blog page would link to `https://github.com/https://github.com/seahorn/seahorn`.